### PR TITLE
github tools: fix fossa workflow file

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -1,0 +1,31 @@
+name: Dependency License Scanning
+
+on:
+  push:
+    branches:
+      - master
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  fossa:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Fossa init
+        run: |-
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
+          fossa init
+      - name: Set env
+        run: echo "line_number=$(grep -n "project" .fossa.yml | cut -f1 -d:)" >> $GITHUB_ENV
+      - name: Configuration
+        run: |-
+          sed -i "${line_number}s|.*|  project: git@github.com:${GITHUB_REPOSITORY}.git|" .fossa.yml
+          cat .fossa.yml
+      - name: Upload dependencies
+        run: fossa analyze --debug
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
Updates github actions fossa workflow to use environment files instead of deprecated set-env command.